### PR TITLE
Tree Node as abstract class

### DIFF
--- a/src/main/java/players/basicMCTS/BasicMCTSEnums.java
+++ b/src/main/java/players/basicMCTS/BasicMCTSEnums.java
@@ -1,0 +1,7 @@
+package players.basicMCTS;
+
+public class BasicMCTSEnums {
+    public enum ExporationStrategy{
+        UCB1
+    }
+}

--- a/src/main/java/players/basicMCTS/BasicMCTSParams.java
+++ b/src/main/java/players/basicMCTS/BasicMCTSParams.java
@@ -14,6 +14,8 @@ public class BasicMCTSParams extends PlayerParameters {
     public int maxTreeDepth = 100; // effectively no limit
     public double epsilon = 1e-6;
     public IStateHeuristic heuristic = AbstractGameState::getHeuristicScore;
+    public BasicMCTSEnums.ExporationStrategy exporationStrategy = BasicMCTSEnums.ExporationStrategy.UCB1;
+    public TreeNodeFactory treeNodeFactory;
 
     public BasicMCTSParams() {
         this(System.currentTimeMillis());
@@ -26,6 +28,8 @@ public class BasicMCTSParams extends PlayerParameters {
         addTunableParameter("maxTreeDepth", 100, Arrays.asList(1, 3, 10, 30, 100));
         addTunableParameter("epsilon", 1e-6);
         addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
+        addTunableParameter("explorationStrategy", BasicMCTSEnums.ExporationStrategy.UCB1, Arrays.asList(BasicMCTSEnums.ExporationStrategy.UCB1));
+        treeNodeFactory = new TreeNodeFactory(exporationStrategy);    
     }
 
     @Override
@@ -36,6 +40,8 @@ public class BasicMCTSParams extends PlayerParameters {
         maxTreeDepth = (int) getParameterValue("maxTreeDepth");
         epsilon = (double) getParameterValue("epsilon");
         heuristic = (IStateHeuristic) getParameterValue("heuristic");
+        exporationStrategy = (BasicMCTSEnums.ExporationStrategy) getParameterValue("explorationStrategy");
+        treeNodeFactory = new TreeNodeFactory(exporationStrategy);    
     }
 
     @Override

--- a/src/main/java/players/basicMCTS/BasicMCTSPlayer.java
+++ b/src/main/java/players/basicMCTS/BasicMCTSPlayer.java
@@ -45,7 +45,7 @@ public class BasicMCTSPlayer extends AbstractPlayer {
     @Override
     public AbstractAction _getAction(AbstractGameState gameState, List<AbstractAction> actions) {
         // Search for best action from the root
-        BasicTreeNode root = new BasicTreeNode(this, null, gameState, rnd);
+        BasicTreeNode root = params.treeNodeFactory.createNode(this, null, gameState, rnd);
 
         // mctsSearch does all of the hard work
         root.mctsSearch();

--- a/src/main/java/players/basicMCTS/TreeNodeFactory.java
+++ b/src/main/java/players/basicMCTS/TreeNodeFactory.java
@@ -1,0 +1,20 @@
+package players.basicMCTS;
+
+import java.util.Random;
+
+import core.AbstractGameState;
+
+public class TreeNodeFactory {
+    BasicMCTSEnums.ExporationStrategy exporationStrategy;
+    public TreeNodeFactory(BasicMCTSEnums.ExporationStrategy exporationStrategy){
+        this.exporationStrategy= exporationStrategy;
+    }
+
+    public BasicTreeNode createNode(BasicMCTSPlayer player, BasicTreeNode parent, AbstractGameState state, Random rnd){
+        if(exporationStrategy == BasicMCTSEnums.ExporationStrategy.UCB1){
+            return new UCB1TreeNode(player, parent, state, rnd);
+        }
+        return new UCB1TreeNode(player, parent, state, rnd);
+    }
+}
+

--- a/src/main/java/players/basicMCTS/UCB1TreeNode.java
+++ b/src/main/java/players/basicMCTS/UCB1TreeNode.java
@@ -1,0 +1,115 @@
+package players.basicMCTS;
+
+import java.util.Random;
+import static utilities.Utils.noise;
+
+import core.AbstractGameState;
+import core.actions.AbstractAction;
+
+public class UCB1TreeNode extends BasicTreeNode{
+    
+    // Total value of this node
+    protected double totValue;
+    // Number of visits
+    protected int nVisits;
+
+    protected UCB1TreeNode(BasicMCTSPlayer player, BasicTreeNode parent, AbstractGameState state, Random rnd) {
+        super(player, parent, state, rnd);
+        totValue = 0.0;
+    }
+
+
+    @Override
+    AbstractAction selectAction() {
+     // Find child with highest UCB value, maximising for ourselves and minimizing for opponent
+     AbstractAction bestAction = null;
+     double bestValue = -Double.MAX_VALUE;
+
+     for (AbstractAction action : children.keySet()) {
+        UCB1TreeNode child = (UCB1TreeNode) children.get(action);
+         if (child == null)
+             throw new AssertionError("Should not be here");
+         else if (bestAction == null)
+             bestAction = action;
+
+         // Find child value
+         double hvVal = child.totValue;
+         double childValue = hvVal / (child.nVisits + player.params.epsilon);
+         double explorationTerm = player.params.K * Math.sqrt(Math.log(this.nVisits + 1) / (child.nVisits + player.params.epsilon));
+
+         // Find 'UCB' value
+         // If 'we' are taking a turn we use classic UCB
+         // If it is an opponent's turn, then we assume they are trying to minimise our score (with exploration)
+         boolean iAmMoving = state.getCurrentPlayer() == player.getPlayerID();
+         double uctValue = iAmMoving ? childValue : -childValue;
+         uctValue += explorationTerm;
+
+         // Apply small noise to break ties randomly
+         uctValue = noise(uctValue, player.params.epsilon, player.rnd.nextDouble());
+
+         // Assign value
+         if (uctValue > bestValue) {
+             bestAction = action;
+             bestValue = uctValue;
+         }
+     }
+
+     if (bestAction == null)
+         throw new AssertionError("We have a null value in UCT : shouldn't really happen!");
+
+     root.fmCallsCount++;  // log one iteration complete
+     return bestAction;
+    }
+    
+    /**
+     * Back up the value of the child through all parents. Increase number of visits and total value.
+     *
+     * @param result - value of rollout to backup
+     */
+    @Override
+    void backUp(double result) {
+
+        UCB1TreeNode n = this;
+        while (n != null) {
+            n.nVisits++;
+            n.totValue += result;
+            n = (UCB1TreeNode) n.parent;
+        }
+    }
+    
+
+    @Override
+    /**
+     * Calculates the best action from the root according to the most visited node
+     *
+     * @return - the best AbstractAction
+     */
+    AbstractAction bestAction() {
+
+        double bestValue = -Double.MAX_VALUE;
+        AbstractAction bestAction = null;
+
+        for (AbstractAction action : children.keySet()) {
+            if (children.get(action) != null) {
+                UCB1TreeNode node = (UCB1TreeNode) children.get(action);
+                double childValue = node.nVisits;
+
+                // Apply small noise to break ties randomly
+                childValue = noise(childValue, player.params.epsilon, player.rnd.nextDouble());
+
+                // Save best value (highest visit count)
+                if (childValue > bestValue) {
+                    bestValue = childValue;
+                    bestAction = action;
+                }
+            }
+        }
+
+        if (bestAction == null) {
+            throw new AssertionError("Unexpected - no selection made.");
+        }
+
+        return bestAction;
+    }
+
+}


### PR DESCRIPTION
Changed the `BasicTreeNode` to be an abstract class, with abstract methods to:
- select the action to select (selection step)
- backpropagate results (backprop step)
- select the best action at the end of the algorithm

This will allow for multiple implementations of different algorithms to solve the explore/exploit problem.

This PR implements a tree node factory that is created from the params, as we do more experimentation, we may need to refine this pattern as we see fit 