### PR TITLE
Tree Node as abstract class

### DIFF
--- a/src/main/java/groupM/players/mcts/MCTSEnums.java
+++ b/src/main/java/groupM/players/mcts/MCTSEnums.java
@@ -1,7 +1,8 @@
 package groupM.players.mcts;
 
 public class MCTSEnums {
-    public enum ExporationStrategy{
+        /** Determins the Tree Policy to handle the explore-exploit dilema*/
+    public enum ExplorationStrategy{
         UCB1
     }
 }

--- a/src/main/java/groupM/players/mcts/MCTSEnums.java
+++ b/src/main/java/groupM/players/mcts/MCTSEnums.java
@@ -1,0 +1,7 @@
+package groupM.players.mcts;
+
+public class MCTSEnums {
+    public enum ExporationStrategy{
+        UCB1
+    }
+}

--- a/src/main/java/groupM/players/mcts/MCTSParams.java
+++ b/src/main/java/groupM/players/mcts/MCTSParams.java
@@ -14,7 +14,7 @@ public class MCTSParams extends PlayerParameters {
     public int maxTreeDepth = 100; // effectively no limit
     public double epsilon = 1e-6;
     public IStateHeuristic heuristic = AbstractGameState::getHeuristicScore;
-    public MCTSEnums.ExporationStrategy exporationStrategy = MCTSEnums.ExporationStrategy.UCB1;
+    public MCTSEnums.ExplorationStrategy exporationStrategy = MCTSEnums.ExplorationStrategy.UCB1;
     public TreeNodeFactory treeNodeFactory;
 
     public MCTSParams() {
@@ -28,7 +28,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("maxTreeDepth", 100, Arrays.asList(1, 3, 10, 30, 100));
         addTunableParameter("epsilon", 1e-6);
         addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
-        addTunableParameter("explorationStrategy", MCTSEnums.ExporationStrategy.UCB1, Arrays.asList(MCTSEnums.ExporationStrategy.UCB1));
+        addTunableParameter("explorationStrategy", MCTSEnums.ExplorationStrategy.UCB1, Arrays.asList(MCTSEnums.ExplorationStrategy.UCB1));
         treeNodeFactory = new TreeNodeFactory(exporationStrategy);    
     }
 
@@ -40,7 +40,7 @@ public class MCTSParams extends PlayerParameters {
         maxTreeDepth = (int) getParameterValue("maxTreeDepth");
         epsilon = (double) getParameterValue("epsilon");
         heuristic = (IStateHeuristic) getParameterValue("heuristic");
-        exporationStrategy = (MCTSEnums.ExporationStrategy) getParameterValue("explorationStrategy");
+        exporationStrategy = (MCTSEnums.ExplorationStrategy) getParameterValue("explorationStrategy");
         treeNodeFactory = new TreeNodeFactory(exporationStrategy);    
     }
 

--- a/src/main/java/groupM/players/mcts/MCTSParams.java
+++ b/src/main/java/groupM/players/mcts/MCTSParams.java
@@ -1,0 +1,64 @@
+package groupM.players.mcts;
+
+import core.AbstractGameState;
+import core.interfaces.IStateHeuristic;
+import players.PlayerParameters;
+
+import java.util.Arrays;
+
+
+public class MCTSParams extends PlayerParameters {
+
+    public double K = Math.sqrt(2);
+    public int rolloutLength = 10; // assuming we have a good heuristic
+    public int maxTreeDepth = 100; // effectively no limit
+    public double epsilon = 1e-6;
+    public IStateHeuristic heuristic = AbstractGameState::getHeuristicScore;
+    public MCTSEnums.ExporationStrategy exporationStrategy = MCTSEnums.ExporationStrategy.UCB1;
+    public TreeNodeFactory treeNodeFactory;
+
+    public MCTSParams() {
+        this(System.currentTimeMillis());
+    }
+
+    public MCTSParams(long seed) {
+        super(seed);
+        addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
+        addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 10, 30, 100));
+        addTunableParameter("maxTreeDepth", 100, Arrays.asList(1, 3, 10, 30, 100));
+        addTunableParameter("epsilon", 1e-6);
+        addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
+        addTunableParameter("explorationStrategy", MCTSEnums.ExporationStrategy.UCB1, Arrays.asList(MCTSEnums.ExporationStrategy.UCB1));
+        treeNodeFactory = new TreeNodeFactory(exporationStrategy);    
+    }
+
+    @Override
+    public void _reset() {
+        super._reset();
+        K = (double) getParameterValue("K");
+        rolloutLength = (int) getParameterValue("rolloutLength");
+        maxTreeDepth = (int) getParameterValue("maxTreeDepth");
+        epsilon = (double) getParameterValue("epsilon");
+        heuristic = (IStateHeuristic) getParameterValue("heuristic");
+        exporationStrategy = (MCTSEnums.ExporationStrategy) getParameterValue("explorationStrategy");
+        treeNodeFactory = new TreeNodeFactory(exporationStrategy);    
+    }
+
+    @Override
+    protected MCTSParams _copy() {
+        // All the copying is done in TunableParameters.copy()
+        // Note that any *local* changes of parameters will not be copied
+        // unless they have been 'registered' with setParameterValue("name", value)
+        return new MCTSParams(System.currentTimeMillis());
+    }
+
+    public IStateHeuristic getHeuristic() {
+        return heuristic;
+    }
+
+    @Override
+    public MCTSPlayer instantiate() {
+        return new MCTSPlayer((MCTSParams) this.copy());
+    }
+
+}

--- a/src/main/java/groupM/players/mcts/MCTSPlayer.java
+++ b/src/main/java/groupM/players/mcts/MCTSPlayer.java
@@ -1,0 +1,72 @@
+package groupM.players.mcts;
+
+import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.actions.AbstractAction;
+import core.interfaces.IStateHeuristic;
+
+import java.util.List;
+import java.util.Random;
+
+
+/**
+ * This is a simple version of MCTS that may be useful for newcomers to TAG and MCTS-like algorithms
+ * It strips out some of the additional configuration of MCTSPlayer. It uses BasicTreeNode in place of
+ * SingleTreeNode.
+ */
+public class MCTSPlayer extends AbstractPlayer {
+
+    Random rnd;
+    MCTSParams params;
+
+    public MCTSPlayer() {
+        this(System.currentTimeMillis());
+    }
+
+    public MCTSPlayer(long seed) {
+        this.params = new MCTSParams(seed);
+        rnd = new Random(seed);
+        setName("Basic MCTS");
+
+        // These parameters can be changed, and will impact the Basic MCTS algorithm
+        this.params.K = Math.sqrt(2);
+        this.params.rolloutLength = 10;
+        this.params.maxTreeDepth = 5;
+        this.params.epsilon = 1e-6;
+
+    }
+
+    public MCTSPlayer(MCTSParams params) {
+        this.params = params;
+        rnd = new Random(params.getRandomSeed());
+        setName("Basic MCTS");
+    }
+
+    @Override
+    public AbstractAction _getAction(AbstractGameState gameState, List<AbstractAction> actions) {
+        // Search for best action from the root
+        TreeNode root = params.treeNodeFactory.createNode(this, null, gameState, rnd);
+
+        // mctsSearch does all of the hard work
+        root.mctsSearch();
+
+        // Return best action
+        return root.bestAction();
+    }
+
+
+    public void setStateHeuristic(IStateHeuristic heuristic) {
+        this.params.heuristic = heuristic;
+    }
+
+
+    @Override
+    public String toString() {
+        return "BasicMCTS";
+    }
+
+    @Override
+    public MCTSPlayer copy() {
+        return this;
+    }
+}

--- a/src/main/java/groupM/players/mcts/TreeNode.java
+++ b/src/main/java/groupM/players/mcts/TreeNode.java
@@ -1,0 +1,236 @@
+package groupM.players.mcts;
+
+import core.AbstractGameState;
+import core.actions.AbstractAction;
+import players.PlayerConstants;
+import players.simple.RandomPlayer;
+import utilities.ElapsedCpuTimer;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+import static players.PlayerConstants.*;
+
+abstract class TreeNode {
+    // Root node of tree
+    TreeNode root;
+    // Parent of this node
+    TreeNode parent;
+    // Children of this node
+    Map<AbstractAction, TreeNode> children = new HashMap<>();
+    // Depth of this node
+    final int depth;
+
+    // Number of FM calls and State copies up until this node
+    protected int fmCallsCount;
+    // Parameters guiding the search
+    protected MCTSPlayer player;
+    private Random rnd;
+    private RandomPlayer randomPlayer = new RandomPlayer();
+
+    // State in this node (closed loop)
+    protected AbstractGameState state;
+
+    protected TreeNode(MCTSPlayer player, TreeNode parent, AbstractGameState state, Random rnd) {
+        this.player = player;
+        this.fmCallsCount = 0;
+        this.parent = parent;
+        this.root = parent == null ? this : parent.root;
+        setState(state);
+        if (parent != null) {
+            depth = parent.depth + 1;
+        } else {
+            depth = 0;
+        }
+        this.rnd = rnd;
+        randomPlayer.setForwardModel(player.getForwardModel());
+    }
+
+    /**
+     * Performs full MCTS search, using the defined budget limits.
+     */
+    void mctsSearch() {
+
+        // Variables for tracking time budget
+        double avgTimeTaken;
+        double acumTimeTaken = 0;
+        long remaining;
+        int remainingLimit = player.params.breakMS;
+        ElapsedCpuTimer elapsedTimer = new ElapsedCpuTimer();
+        if (player.params.budgetType == BUDGET_TIME) {
+            elapsedTimer.setMaxTimeMillis(player.params.budget);
+        }
+
+        // Tracking number of iterations for iteration budget
+        int numIters = 0;
+
+        boolean stop = false;
+
+        while (!stop) {
+            // New timer for this iteration
+            ElapsedCpuTimer elapsedTimerIteration = new ElapsedCpuTimer();
+
+            // Selection + expansion: navigate tree until a node not fully expanded is found, add a new node to the tree
+            TreeNode selected = treePolicy();
+            // Monte carlo rollout: return value of MC rollout from the newly added node
+            double delta = selected.rollOut();
+            // Back up the value of the rollout through the tree
+            selected.backUp(delta);
+            // Finished iteration
+            numIters++;
+
+            // Check stopping condition
+            PlayerConstants budgetType = player.params.budgetType;
+            if (budgetType == BUDGET_TIME) {
+                // Time budget
+                acumTimeTaken += (elapsedTimerIteration.elapsedMillis());
+                avgTimeTaken = acumTimeTaken / numIters;
+                remaining = elapsedTimer.remainingTimeMillis();
+                stop = remaining <= 2 * avgTimeTaken || remaining <= remainingLimit;
+            } else if (budgetType == BUDGET_ITERATIONS) {
+                // Iteration budget
+                stop = numIters >= player.params.budget;
+            } else if (budgetType == BUDGET_FM_CALLS) {
+                // FM calls budget
+                stop = fmCallsCount > player.params.budget;
+            }
+        }
+    }
+
+    /**
+     * Selection + expansion steps.
+     * - Tree is traversed until a node not fully expanded is found.
+     * - A new child of this node is added to the tree.
+     *
+     * @return - new node added to the tree.
+     */
+    private TreeNode treePolicy() {
+
+        TreeNode cur = this;
+
+        // Keep iterating while the state reached is not terminal and the depth of the tree is not exceeded
+        while (cur.state.isNotTerminal() && cur.depth < player.params.maxTreeDepth) {
+            if (!cur.unexpandedActions().isEmpty()) {
+                // We have an unexpanded action
+                cur = cur.expand();
+                return cur;
+            } else {
+                // Move to next child given by UCT function
+                AbstractAction actionChosen = cur.selectAction();
+                cur = cur.children.get(actionChosen); 
+            }
+        }
+
+        return cur;
+    }
+
+    private void setState(AbstractGameState newState) {
+        state = newState;
+        if (newState.isNotTerminal())
+            for (AbstractAction action : player.getForwardModel().computeAvailableActions(state, player.params.actionSpace)) {
+                children.put(action, null); // mark a new node to be expanded
+            }
+    }
+
+    /**
+     * @return A list of the unexpanded Actions from this State
+     */
+    private List<AbstractAction> unexpandedActions() {
+        return children.keySet().stream().filter(a -> children.get(a) == null).collect(toList());
+    }
+
+    /**
+     * Expands the node by creating a new random child node and adding to the tree.
+     *
+     * @return - new child node.
+     */
+    private TreeNode expand() {
+        // Find random child not already created
+        Random r = new Random(player.params.getRandomSeed());
+        // pick a random unchosen action
+        List<AbstractAction> notChosen = unexpandedActions();
+        AbstractAction chosen = notChosen.get(r.nextInt(notChosen.size()));
+
+        // copy the current state and advance it using the chosen action
+        // we first copy the action so that the one stored in the node will not have any state changes
+        AbstractGameState nextState = state.copy();
+        advance(nextState, chosen.copy());
+
+        // then instantiate a new node
+        TreeNode tn = player.params.treeNodeFactory.createNode(player, this, nextState, rnd);
+        children.put(chosen, tn);
+        return tn;
+    }
+
+    /**
+     * Advance the current game state with the given action, count the FM call and compute the next available actions.
+     *
+     * @param gs  - current game state
+     * @param act - action to apply
+     */
+    private void advance(AbstractGameState gs, AbstractAction act) {
+        player.getForwardModel().next(gs, act);
+        root.fmCallsCount++;
+    }
+
+    /**
+     * Perform a Monte Carlo rollout from this node.
+     *
+     * @return - value of rollout.
+     */
+    private double rollOut() {
+        int rolloutDepth = 0; // counting from end of tree
+
+        // If rollouts are enabled, select actions for the rollout in line with the rollout policy
+        AbstractGameState rolloutState = state.copy();
+        if (player.params.rolloutLength > 0) {
+            while (!finishRollout(rolloutState, rolloutDepth)) {
+                AbstractAction next = randomPlayer.getAction(rolloutState, randomPlayer.getForwardModel().computeAvailableActions(rolloutState, randomPlayer.parameters.actionSpace));
+                advance(rolloutState, next);
+                rolloutDepth++;
+            }
+        }
+        // Evaluate final state and return normalised score
+        double value = player.params.getHeuristic().evaluateState(rolloutState, player.getPlayerID());
+        if (Double.isNaN(value))
+            throw new AssertionError("Illegal heuristic value - should be a number");
+        return value;
+    }
+
+    /**
+     * Checks if rollout is finished. Rollouts end on maximum length, or if game ended.
+     *
+     * @param rollerState - current state
+     * @param depth       - current depth
+     * @return - true if rollout finished, false otherwise
+     */
+    private boolean finishRollout(AbstractGameState rollerState, int depth) {
+        if (depth >= player.params.rolloutLength)
+            return true;
+
+        // End of game
+        return !rollerState.isNotTerminal();
+    }
+
+    /**
+     * Selects the action to take from the current node.
+     * Must handle the explore/exploit dilemma
+     * @return the action
+     */
+    abstract AbstractAction selectAction();
+
+    /**
+     * Back up the value of the child through all parents.
+     *
+     * @param result - value of rollout to backup
+     */
+    abstract void backUp(double result);
+
+    /**
+     * Calculates the best action from the root according to algorithm
+     *
+     * @return - the best AbstractAction
+     */
+    abstract AbstractAction bestAction();
+
+}

--- a/src/main/java/groupM/players/mcts/TreeNodeFactory.java
+++ b/src/main/java/groupM/players/mcts/TreeNodeFactory.java
@@ -1,0 +1,20 @@
+package groupM.players.mcts;
+
+import java.util.Random;
+
+import core.AbstractGameState;
+
+public class TreeNodeFactory {
+    MCTSEnums.ExporationStrategy exporationStrategy;
+    public TreeNodeFactory(MCTSEnums.ExporationStrategy exporationStrategy){
+        this.exporationStrategy= exporationStrategy;
+    }
+
+    public TreeNode createNode(MCTSPlayer player, TreeNode parent, AbstractGameState state, Random rnd){
+        if(exporationStrategy == MCTSEnums.ExporationStrategy.UCB1){
+            return new UCB1TreeNode(player, parent, state, rnd);
+        }
+        return new UCB1TreeNode(player, parent, state, rnd);
+    }
+}
+

--- a/src/main/java/groupM/players/mcts/TreeNodeFactory.java
+++ b/src/main/java/groupM/players/mcts/TreeNodeFactory.java
@@ -5,13 +5,13 @@ import java.util.Random;
 import core.AbstractGameState;
 
 public class TreeNodeFactory {
-    MCTSEnums.ExporationStrategy exporationStrategy;
-    public TreeNodeFactory(MCTSEnums.ExporationStrategy exporationStrategy){
+    MCTSEnums.ExplorationStrategy exporationStrategy;
+    public TreeNodeFactory(MCTSEnums.ExplorationStrategy exporationStrategy){
         this.exporationStrategy= exporationStrategy;
     }
 
     public TreeNode createNode(MCTSPlayer player, TreeNode parent, AbstractGameState state, Random rnd){
-        if(exporationStrategy == MCTSEnums.ExporationStrategy.UCB1){
+        if(exporationStrategy == MCTSEnums.ExplorationStrategy.UCB1){
             return new UCB1TreeNode(player, parent, state, rnd);
         }
         return new UCB1TreeNode(player, parent, state, rnd);

--- a/src/main/java/groupM/players/mcts/UCB1TreeNode.java
+++ b/src/main/java/groupM/players/mcts/UCB1TreeNode.java
@@ -1,0 +1,115 @@
+package groupM.players.mcts;
+
+import java.util.Random;
+import static utilities.Utils.noise;
+
+import core.AbstractGameState;
+import core.actions.AbstractAction;
+
+public class UCB1TreeNode extends TreeNode{
+    
+    // Total value of this node
+    protected double totValue;
+    // Number of visits
+    protected int nVisits;
+
+    protected UCB1TreeNode(MCTSPlayer player, TreeNode parent, AbstractGameState state, Random rnd) {
+        super(player, parent, state, rnd);
+        totValue = 0.0;
+    }
+
+
+    @Override
+    AbstractAction selectAction() {
+     // Find child with highest UCB value, maximising for ourselves and minimizing for opponent
+     AbstractAction bestAction = null;
+     double bestValue = -Double.MAX_VALUE;
+
+     for (AbstractAction action : children.keySet()) {
+        UCB1TreeNode child = (UCB1TreeNode) children.get(action);
+         if (child == null)
+             throw new AssertionError("Should not be here");
+         else if (bestAction == null)
+             bestAction = action;
+
+         // Find child value
+         double hvVal = child.totValue;
+         double childValue = hvVal / (child.nVisits + player.params.epsilon);
+         double explorationTerm = player.params.K * Math.sqrt(Math.log(this.nVisits + 1) / (child.nVisits + player.params.epsilon));
+
+         // Find 'UCB' value
+         // If 'we' are taking a turn we use classic UCB
+         // If it is an opponent's turn, then we assume they are trying to minimise our score (with exploration)
+         boolean iAmMoving = state.getCurrentPlayer() == player.getPlayerID();
+         double uctValue = iAmMoving ? childValue : -childValue;
+         uctValue += explorationTerm;
+
+         // Apply small noise to break ties randomly
+         uctValue = noise(uctValue, player.params.epsilon, player.rnd.nextDouble());
+
+         // Assign value
+         if (uctValue > bestValue) {
+             bestAction = action;
+             bestValue = uctValue;
+         }
+     }
+
+     if (bestAction == null)
+         throw new AssertionError("We have a null value in UCT : shouldn't really happen!");
+
+     root.fmCallsCount++;  // log one iteration complete
+     return bestAction;
+    }
+    
+    /**
+     * Back up the value of the child through all parents. Increase number of visits and total value.
+     *
+     * @param result - value of rollout to backup
+     */
+    @Override
+    void backUp(double result) {
+
+        UCB1TreeNode n = this;
+        while (n != null) {
+            n.nVisits++;
+            n.totValue += result;
+            n = (UCB1TreeNode) n.parent;
+        }
+    }
+    
+
+    @Override
+    /**
+     * Calculates the best action from the root according to the most visited node
+     *
+     * @return - the best AbstractAction
+     */
+    AbstractAction bestAction() {
+
+        double bestValue = -Double.MAX_VALUE;
+        AbstractAction bestAction = null;
+
+        for (AbstractAction action : children.keySet()) {
+            if (children.get(action) != null) {
+                UCB1TreeNode node = (UCB1TreeNode) children.get(action);
+                double childValue = node.nVisits;
+
+                // Apply small noise to break ties randomly
+                childValue = noise(childValue, player.params.epsilon, player.rnd.nextDouble());
+
+                // Save best value (highest visit count)
+                if (childValue > bestValue) {
+                    bestValue = childValue;
+                    bestAction = action;
+                }
+            }
+        }
+
+        if (bestAction == null) {
+            throw new AssertionError("Unexpected - no selection made.");
+        }
+
+        return bestAction;
+    }
+
+}


### PR DESCRIPTION
Changed the BasicTreeNode to be an abstract class, with abstract methods to:

- select the action to select (selection step)
- backpropagate results (backprop step)
- select the best action at the end of the algorithm

This will allow for multiple implementations of different algorithms to solve the explore/exploit problem.

This PR implements a tree node factory that is created from the params, as we do more experimentation, we may need to refine this pattern as we see fit