### PR TITLE
adding breadth first player

### DIFF
--- a/src/main/java/groupM/players/breadthFirst/BreadthFirstParams.java
+++ b/src/main/java/groupM/players/breadthFirst/BreadthFirstParams.java
@@ -1,0 +1,40 @@
+package groupM.players.breadthFirst;
+
+import core.AbstractGameState;
+import core.interfaces.IStateHeuristic;
+import players.PlayerParameters;
+
+public class BreadthFirstParams extends PlayerParameters {
+
+    public IStateHeuristic heuristic = AbstractGameState::getHeuristicScore;
+
+    public BreadthFirstParams() {
+        super(System.currentTimeMillis());
+        addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
+    }
+
+    public IStateHeuristic getHeuristic() {
+        return heuristic;
+    }
+
+    @Override
+    protected BreadthFirstParams _copy() {
+        // All the copying is done in TunableParameters.copy()
+        // Note that any *local* changes of parameters will not be copied
+        // unless they have been 'registered' with setParameterValue("name", value)
+        BreadthFirstParams params =  new BreadthFirstParams();
+        params.setRandomSeed(super.getRandomSeed());
+        return params;
+    }
+
+    @Override
+    public void _reset() {
+        super._reset();
+        heuristic = (IStateHeuristic) getParameterValue("heuristic");
+    }
+
+    @Override
+    public BreadthFirstPlayer instantiate() {
+        return new BreadthFirstPlayer((BreadthFirstParams) this.copy());
+    }
+}

--- a/src/main/java/groupM/players/breadthFirst/BreadthFirstPlayer.java
+++ b/src/main/java/groupM/players/breadthFirst/BreadthFirstPlayer.java
@@ -1,0 +1,74 @@
+package groupM.players.breadthFirst;
+
+import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.actions.AbstractAction;
+import players.PlayerConstants;
+import utilities.ElapsedCpuTimer;
+
+import java.util.*;
+
+import static players.PlayerConstants.BUDGET_TIME;
+
+public class BreadthFirstPlayer extends AbstractPlayer {
+
+    BreadthFirstParams params;
+
+    Map<AbstractGameState, BreadthFirstTreeNode> stateToNodeMap = new HashMap<AbstractGameState, BreadthFirstTreeNode>();
+
+    public BreadthFirstPlayer(BreadthFirstParams params) {
+        this.params = params;
+        setName("Breadth First");
+    }
+
+    @Override
+    public AbstractAction _getAction(AbstractGameState gameState, List<AbstractAction> possibleActions) {
+        ElapsedCpuTimer timer = new ElapsedCpuTimer();  // New timer for this game tick
+        timer.setMaxTimeMillis(params.budget);
+        double acumTimeTaken = 0;
+
+        long remaining;
+        int remainingLimit = this.params.breakMS;
+
+        // Search for best action from the root
+        BreadthFirstTreeNode root = new BreadthFirstTreeNode(this, null, gameState);
+
+        Queue<BreadthFirstTreeNode> queue = new LinkedList<BreadthFirstTreeNode>();
+        BreadthFirstTreeNode current = root;
+
+        boolean stop = false;
+        // Check stopping condition
+        PlayerConstants budgetType = this.params.budgetType;
+
+        while (!stop) {
+            queue.addAll(current.expand());
+            double delta = current.rollOut();
+
+            // Back up the value of the rollout through the tree. We still do this regardless of above because we might
+            // because we might have reached this state through a different route.
+            current.backUp(delta);
+
+            current = queue.poll();
+
+            if (budgetType == BUDGET_TIME) {
+                // Time budget
+                stop = timer.remainingTimeMillis() <= remainingLimit;
+            }
+            if (current == null) {
+                stop = true;
+            }
+        }
+
+        return root.bestAction();
+    }
+
+    @Override
+    public String toString() {
+        return "BreadthFirst";
+    }
+
+    @Override
+    public BreadthFirstPlayer copy() {
+        return this;
+    }
+}

--- a/src/main/java/groupM/players/breadthFirst/BreadthFirstTreeNode.java
+++ b/src/main/java/groupM/players/breadthFirst/BreadthFirstTreeNode.java
@@ -1,0 +1,148 @@
+package groupM.players.breadthFirst;
+
+import core.AbstractForwardModel;
+import core.AbstractGameState;
+import core.actions.AbstractAction;
+
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+
+public class BreadthFirstTreeNode {
+    // Root node of tree
+    BreadthFirstTreeNode root;
+    // Parent of this node
+    BreadthFirstTreeNode parent;
+    // Children of this node
+    Map<AbstractAction, BreadthFirstTreeNode> children = new HashMap<>();
+
+    // Total value of this node
+    double totValue;
+
+    // Number of FM calls and State copies up until this node
+    private int fmCallsCount;
+
+    private BreadthFirstPlayer player;
+
+    private BreadthFirstPlayer opponent;
+
+    // State in this node (closed loop)
+    private AbstractGameState state;
+
+    protected BreadthFirstTreeNode(BreadthFirstPlayer player, BreadthFirstTreeNode parent, AbstractGameState state) {
+        this.player = player;
+        this.opponent = new BreadthFirstPlayer(player.params);
+        this.opponent.setForwardModel(player.getForwardModel());
+        this.parent = parent;
+        this.root = parent == null ? this : parent.root;
+        totValue = 0.0;
+        setState(state);
+    }
+
+    AbstractGameState getState() {
+        return state;
+    }
+
+    /**
+     * @return A list of the unexpanded Actions from this State
+     */
+    List<AbstractAction> unexpandedActions() {
+        return children.keySet().stream().filter(a -> children.get(a) == null).collect(toList());
+    }
+
+    /**
+     * Expands the node by creating any necessary child nodes and adding them to the tree,
+     * then returns all child nodes.
+     *
+     * @return - Expanded child nodes.
+     */
+    Collection<BreadthFirstTreeNode> expand() {
+        List<AbstractAction> notChosen = unexpandedActions();// copy the current state and advance it using the chosen action
+
+        for (AbstractAction next : notChosen) {
+            // we first copy the action so that the one stored in the node will not have any state changes
+            AbstractGameState nextState = state.copy();
+            advance(nextState, next.copy());
+
+            // then instantiate a new node
+            BreadthFirstTreeNode tn = new BreadthFirstTreeNode(player, this, nextState);
+            children.put(next, tn);
+        }
+        return children.values();
+    }
+
+    /**
+     * Evaluate the outcome of this node for every possible opponent action from this state
+     *
+     * @return - value of rollout.
+     */
+    double rollOut() {
+        double value = 0;
+        // If rollouts are enabled, select actions for the rollout in line with the rollout policy
+        AbstractGameState rolloutState = state.copy();
+        AbstractForwardModel forwardModel = opponent.getForwardModel();
+        List<AbstractAction> actions = forwardModel.computeAvailableActions(rolloutState, opponent.parameters.actionSpace);
+        int count = 0;
+        for (AbstractAction next : actions) {
+            rolloutState = state.copy();
+            advance(rolloutState, next);
+            value += player.params.getHeuristic().evaluateState(rolloutState, player.getPlayerID());
+            count++;
+        }
+        // Evaluate final state and return normalised score
+        return count > 0 ? value / count : value;
+    }
+
+    void setState(AbstractGameState newState) {
+        state = newState;
+        if (newState.isNotTerminal()) {
+            for (AbstractAction action : player.getForwardModel().computeAvailableActions(state, player.params.actionSpace)) {
+                children.put(action, null); // mark a new node to be expanded
+            }
+        }
+    }
+
+    void backUp(double result) {
+        BreadthFirstTreeNode n = this;
+        while (n != null) {
+            n.totValue += result;
+            n = n.parent;
+        }
+        player.stateToNodeMap.put(state.copy(),this);
+    }
+
+    /**
+     * Advance the current game state with the given action and compute the next available actions.
+     *
+     * @param gs  - current game state
+     * @param act - action to apply
+     */
+    private void advance(AbstractGameState gs, AbstractAction act) {
+        player.getForwardModel().next(gs, act);
+    }
+
+    AbstractAction bestAction() {
+
+        double bestValue = -Double.MAX_VALUE;
+        AbstractAction bestAction = null;
+
+        for (AbstractAction action : children.keySet()) {
+            if (children.get(action) != null) {
+                BreadthFirstTreeNode node = children.get(action);
+                double childValue = node.totValue;
+                // Save best value (highest visit count)
+                if (childValue > bestValue) {
+                    bestValue = childValue;
+                    bestAction = action;
+                }
+            }
+        }
+
+        if (bestAction == null) {
+            throw new AssertionError("Unexpected - no selection made.");
+        }
+
+        return bestAction;
+    }
+}

--- a/src/main/java/groupM/players/breadthFirst/breadthfirst.json
+++ b/src/main/java/groupM/players/breadthFirst/breadthfirst.json
@@ -1,0 +1,8 @@
+{
+  "class" : "groupM.players.breadthFirst.BreadthFirstParams",
+  "heuristic" : {
+    "class" : "players.heuristics.ScoreHeuristic"
+  },
+  "budgetType" : "BUDGET_TIME",
+  "budget" : 40
+}


### PR DESCRIPTION
Game: SushiGo, Players: 2, GamesPerMatchup: 500, Mode: NO_SELF_PLAY
BreadthFirst got 806.50 points. BreadthFirst won 80.5% of the 1000 games of the tournament. BreadthFirst won 80.5% of the 1000 games it played during the tournament.
BreadthFirst won 80.5% of the 1000 games against Random.

Random got 193.50 points. Random won 19.2% of the 1000 games of the tournament. Random won 19.2% of the 1000 games it played during the tournament.
Random won 19.2% of the 1000 games against BreadthFirst.

---- Ranking ---- 
BreadthFirst: Win rate 0.81 +/- 0.00	Mean Ordinal 1.19 +/- 0.00
Random: Win rate 0.19 +/- 0.00	Mean Ordinal 1.81 +/- 0.00